### PR TITLE
default value of ONLY_ACTIVE_ARCH for debug build may not be set

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -415,7 +415,6 @@ module Xcodeproj
         'GCC_OPTIMIZATION_LEVEL'              => '0',
         'GCC_PREPROCESSOR_DEFINITIONS'        => ['DEBUG=1', '$(inherited)'],
         'MTL_ENABLE_DEBUG_INFO'               => 'INCLUDE_SOURCE',
-        'ONLY_ACTIVE_ARCH'                    => 'YES',
         'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'DEBUG',
         'SWIFT_OPTIMIZATION_LEVEL'            => '-Onone',
       }.freeze,


### PR DESCRIPTION
I'm not a fulltime macOS/iOS developer so I'm not sure, but current Xcode 13 seems to have the default value NO for ONLY_ACTIVE_ARCH on Debug build setting.
(I know new project has ONLY_ACTIVE_ARCH yes for debug build.)

I wonder CocoaPods should not set ONLY_ACTIVE_ARCH to YES.

This ease many of those issues and questions.
- https://github.com/CocoaPods/CocoaPods/issues/11304
- https://stackoverflow.com/search?q=%5Bcocoapods%5D+only+active
  - https://stackoverflow.com/questions/19419781/cocoapods-arm64-issue/21789212#21789212
  - https://stackoverflow.com/questions/26160952/build-active-architecture-only-for-cocoapods-needs-to-be-no-in-xcode

https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW157